### PR TITLE
Typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
 http.ListenAndServe(":8080", logger.Handler(mux, os.Stdout, logger.DevLoggerType))
 ```
 
-## Supportted log output format
+## Supported log output format
 
 ### CombineLoggerType
 


### PR DESCRIPTION
I'm not sure if you're interested in a PR as it looks like it's been a quite stable project for quite a while, but I noticed an extra `t` lying around.